### PR TITLE
Add session storage and Navigation to the next page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import GlobalStyles from './GlobalStyles';
 import Welcome from './pages/Welcome';
+import Genres from './pages/Genres';
 
 function App() {
   return (
@@ -11,6 +12,9 @@ function App() {
         <Switch>
           <Route exact path="/">
             <Welcome />
+          </Route>
+          <Route path="/Genres">
+            <Genres />
           </Route>
         </Switch>
       </Router>

--- a/client/src/components/Input.js
+++ b/client/src/components/Input.js
@@ -11,7 +11,7 @@ const Input = styled.input`
   border: none;
   border-bottom: 1px solid #707070;
   cursor: text;
-  padding: ${(props) => inputText[props.size].padding};
+  padding-top: ${(props) => inputText[props.size].padding};
   font-size: ${(props) => inputText[props.size].fontsize};
   &::placeholder {
     font-family: 'Quicksand Light', sans-serif;
@@ -21,8 +21,8 @@ const Input = styled.input`
 `;
 
 const inputText = {
-  Name: { padding: '6px', fontsize: '1.56rem', width: '80%' },
-  User: { padding: '5px', fontsize: '1.25rem', width: '100%' },
+  Name: { padding: '30px', fontsize: '34px', width: '80%' },
+  User: { padding: '30px', fontsize: '20px', width: '100%' },
 };
 
 export default Input;

--- a/client/src/components/layout/Content.js
+++ b/client/src/components/layout/Content.js
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+const Content = styled.div`
+display: flex:
+flex-direction: column;
+align-items: center;
+justify-content: center;
+width: 100%;
+padding: 0px 35px;
+`;
+
+export default Content;

--- a/client/src/components/layout/Form.js
+++ b/client/src/components/layout/Form.js
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+export default Form;

--- a/client/src/pages/Genres.js
+++ b/client/src/pages/Genres.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Button from '../components/Button';
+
+const Content = styled.div`
+display: flex:
+flex-direction: column;
+align-items: center;
+justify-content: center;
+width: 100%;
+padding: 0px 35px;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+const Text = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  font-family: 'Quicksand Light';
+  margin-top: 80px;
+`;
+
+function Genres() {
+  return (
+    <Content>
+      <Form>
+        <Text>Which Music Do You Like?</Text>
+        <Button size="Match" />
+      </Form>
+    </Content>
+  );
+}
+
+export default Genres;

--- a/client/src/pages/Genres.js
+++ b/client/src/pages/Genres.js
@@ -22,6 +22,7 @@ const Form = styled.form`
 const Text = styled.div`
   display: flex;
   flex-wrap: wrap;
+  text-align: center;
   font-family: 'Quicksand Light';
   margin-top: 80px;
 `;
@@ -31,7 +32,7 @@ function Genres() {
     <Content>
       <Form>
         <Text>Which Music Do You Like?</Text>
-        <Button size="Match" />
+        <Button size="Large">Match Me</Button>
       </Form>
     </Content>
   );

--- a/client/src/pages/Genres.js
+++ b/client/src/pages/Genres.js
@@ -1,23 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Button from '../components/Button';
-
-const Content = styled.div`
-display: flex:
-flex-direction: column;
-align-items: center;
-justify-content: center;
-width: 100%;
-padding: 0px 35px;
-`;
-
-const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-`;
+import Content from '../components/layout/Content';
+import Form from '../components/layout/Form';
 
 const Text = styled.div`
   display: flex;

--- a/client/src/pages/Welcome.js
+++ b/client/src/pages/Welcome.js
@@ -50,20 +50,21 @@ const HighlightLink = styled.div`
 `;
 
 function Welcome() {
-  const [nameUser, setNameUser] = React.useState('');
+  const [nameUser, setNameUser] = React.useState(
+    sessionStorage.getItem('Name') || ''
+  );
+
+  React.useEffect(() => {
+    sessionStorage.setItem('Name', nameUser);
+  }, [nameUser]);
+
+  const onChange = (event) => setNameUser(event.target.value);
 
   return (
     <Content>
       <Form>
         <WelcomeText>Welcome</WelcomeText>
-        <Input
-          type="text"
-          size="Name"
-          value={nameUser}
-          onChange={(event) => {
-            setNameUser(event.target.value);
-          }}
-        />
+        <Input type="text" size="Name" value={nameUser} onChange={onChange} />
         <NameText>Type Your Name</NameText>
         <LoginLink>
           <LoginText>Have An Account?</LoginText>

--- a/client/src/pages/Welcome.js
+++ b/client/src/pages/Welcome.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Input from '../components/Input';
+import { useHistory } from 'react-router-dom';
 import Content from '../components/layout/Content';
 import Form from '../components/layout/Form';
 
@@ -35,6 +36,7 @@ const HighlightLink = styled.div`
 `;
 
 function Welcome() {
+  const history = useHistory();
   const [nameUser, setNameUser] = React.useState(
     sessionStorage.getItem('Name') || ''
   );
@@ -44,6 +46,12 @@ function Welcome() {
   }, [nameUser]);
 
   const onChange = (event) => setNameUser(event.target.value);
+
+  const keyboardEnter = (event) => {
+    if (event.keyCode === 13) {
+      history.push('/Genres');
+    }
+  };
 
   return (
     <Content>
@@ -55,6 +63,7 @@ function Welcome() {
           maxLength={11}
           value={nameUser}
           onChange={onChange}
+          onKeyDown={(event) => keyboardEnter(event)}
         />
         <NameText>Type Your Name</NameText>
         <LoginLink>

--- a/client/src/pages/Welcome.js
+++ b/client/src/pages/Welcome.js
@@ -64,7 +64,13 @@ function Welcome() {
     <Content>
       <Form>
         <WelcomeText>Welcome</WelcomeText>
-        <Input type="text" size="Name" value={nameUser} onChange={onChange} />
+        <Input
+          type="text"
+          size="Name"
+          maxLength={11}
+          value={nameUser}
+          onChange={onChange}
+        />
         <NameText>Type Your Name</NameText>
         <LoginLink>
           <LoginText>Have An Account?</LoginText>

--- a/client/src/pages/Welcome.js
+++ b/client/src/pages/Welcome.js
@@ -1,23 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Input from '../components/Input';
-
-const Content = styled.div`
-display: flex:
-flex-direction: column;
-align-items: center;
-justify-content: center;
-width: 100%;
-padding: 0px 35px;
-`;
-
-const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-`;
+import Content from '../components/layout/Content';
+import Form from '../components/layout/Form';
 
 const WelcomeText = styled.div`
   padding-top: 255px;

--- a/client/src/pages/Welcome.js
+++ b/client/src/pages/Welcome.js
@@ -41,14 +41,11 @@ function Welcome() {
     sessionStorage.getItem('Name') || ''
   );
 
-  React.useEffect(() => {
-    sessionStorage.setItem('Name', nameUser);
-  }, [nameUser]);
-
   const onChange = (event) => setNameUser(event.target.value);
 
   const keyboardEnter = (event) => {
     if (event.keyCode === 13) {
+      sessionStorage.setItem('Name', nameUser);
       history.push('/Genres');
     }
   };


### PR DESCRIPTION
I created a session storage for the name you can use in the app as well as the navigation to the next (in the making) page, when you push enter after entering your name.
As the name will only be used once again and probably won't become a distinctive username, it will only go to the session storage and nothing will be passed on to the next page. The aim is to have a personalised result page (where the stored name will be retrieved again) without the need for registration.
