### PR TITLE
Reduce genre duplicates and sort them alphabetically

### DIFF
--- a/client/src/components/ChooseGenres.js
+++ b/client/src/components/ChooseGenres.js
@@ -34,7 +34,7 @@ async function fetchGenres() {
   const response = await fetch('/festivals');
   const festivals = await response.json();
 
-  const genreArray = festivals.reduce(function (newArray, festivalGenres) {
+  const genreArray = festivals.reduce((newArray, festivalGenres) => {
     if (newArray.indexOf(festivalGenres.genres) === -1) {
       newArray.push(festivalGenres.genres);
     }

--- a/client/src/components/ChooseGenres.js
+++ b/client/src/components/ChooseGenres.js
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 const Genrechoice = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  margin-bottom: 20px;
+  margin-bottom: 35px;
   background-image: linear-gradient(
     145deg,
     rgba(255, 247, 0, 0.5),
@@ -23,7 +23,7 @@ const Genrechoice = styled.div`
   );
 `;
 const Cell = styled.div`
-  padding: 2px;
+  padding: 10px;
   overflow: hidden;
 `;
 const Fill = styled.div`

--- a/client/src/components/ChooseGenres.js
+++ b/client/src/components/ChooseGenres.js
@@ -44,7 +44,7 @@ async function fetchGenres() {
   return genreArray;
 }
 
-function GetGenres() {
+function ChooseGenres() {
   const { status, data: genredata, error } = useQuery('festivals', fetchGenres);
   if (status === 'loading') {
     return <span>Loading...</span>;
@@ -70,4 +70,4 @@ function GetGenres() {
   );
 }
 
-export default GetGenres;
+export default ChooseGenres;

--- a/client/src/components/ChooseGenres.js
+++ b/client/src/components/ChooseGenres.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import GenreButton from '../components/GenreButton';
+import styled from '@emotion/styled';
+import { useQuery } from 'react-query';
+
+const Genrechoice = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 20px;
+  background-image: linear-gradient(
+    145deg,
+    rgba(255, 247, 0, 0.5),
+    rgba(255, 145, 0, 0.5),
+    rgba(255, 0, 132, 0.5),
+    rgba(255, 0, 242, 0.5),
+    rgba(187, 0, 255, 0.5),
+    rgba(85, 0, 255, 0.5),
+    rgba(0, 106, 255, 0.5),
+    rgba(0, 204, 255, 0.5),
+    rgba(0, 255, 106, 0.5),
+    rgba(89, 255, 0, 0.5),
+    rgba(255, 247, 0, 0.5)
+  );
+`;
+const Cell = styled.div`
+  padding: 2px;
+  overflow: hidden;
+`;
+const Fill = styled.div`
+  background: #f9f9f9;
+`;
+
+async function fetchGenres() {
+  const response = await fetch('/festivals');
+  const festivals = await response.json();
+
+  const genreArray = festivals.reduce(function (newArray, festivalGenres) {
+    if (newArray.indexOf(festivalGenres.genres) === -1) {
+      newArray.push(festivalGenres.genres);
+    }
+    return [...new Set([].concat(...newArray))].sort();
+  }, []);
+
+  return genreArray;
+}
+
+function GetGenres() {
+  const { status, data: genredata, error } = useQuery('festivals', fetchGenres);
+  if (status === 'loading') {
+    return <span>Loading...</span>;
+  }
+
+  if (status === 'error') {
+    return <span>Error: {error.message}</span>;
+  }
+
+  return (
+    <div>
+      <Genrechoice>
+        {genredata.map((genre) => (
+          <div key={genre}>
+            <Cell>
+              <GenreButton>{genre}</GenreButton>
+            </Cell>
+          </div>
+        ))}
+        <Fill />
+      </Genrechoice>
+    </div>
+  );
+}
+
+export default GetGenres;

--- a/client/src/components/GenreButton.js
+++ b/client/src/components/GenreButton.js
@@ -11,15 +11,7 @@ const GenreButton = styled.button`
   background: transparent;
   border-radius: 1rem;
   padding-top: 5px;
-  margin-right: 10px;
   margin-top: 10px;
   box-shadow: 0 0 0px 50px #f9f9f9;
 `;
 export default GenreButton;
-
-// &::active: {
-//     transition: 0.25s linear;
-//     color: #000;
-//     opacity: 100%;
-//     background: none;
-//   }

--- a/client/src/components/GenreButton.js
+++ b/client/src/components/GenreButton.js
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+const GenreButton = styled.button`
+  width: 8.3rem;
+  height: 2.75rem;
+  border: none;
+  color: #000;
+  font-family: 'Quicksand Book', sans-serif;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  background: transparent;
+  border-radius: 1rem;
+  padding-top: 5px;
+  margin-right: 10px;
+  margin-top: 10px;
+  box-shadow: 0 0 0px 50px #f9f9f9;
+`;
+export default GenreButton;
+
+// &::active: {
+//     transition: 0.25s linear;
+//     color: #000;
+//     opacity: 100%;
+//     background: none;
+//   }

--- a/client/src/pages/Genres.js
+++ b/client/src/pages/Genres.js
@@ -11,6 +11,7 @@ const Text = styled.div`
   text-align: center;
   font-family: 'Quicksand Light';
   margin-top: 80px;
+  margin-bottom: 25px;
 `;
 
 function Genres() {

--- a/client/src/pages/Genres.js
+++ b/client/src/pages/Genres.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Button from '../components/Button';
 import Content from '../components/layout/Content';
 import Form from '../components/layout/Form';
+import GetGenres from '../components/ChooseGenres';
 
 const Text = styled.div`
   display: flex;
@@ -17,6 +18,7 @@ function Genres() {
     <Content>
       <Form>
         <Text>Which Music Do You Like?</Text>
+        <GetGenres />
         <Button size="Large">Match Me</Button>
       </Form>
     </Content>

--- a/client/src/pages/Genres.js
+++ b/client/src/pages/Genres.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import Button from '../components/Button';
 import Content from '../components/layout/Content';
 import Form from '../components/layout/Form';
-import GetGenres from '../components/ChooseGenres';
+import ChooseGenres from '../components/ChooseGenres';
 
 const Text = styled.div`
   display: flex;
@@ -19,7 +19,7 @@ function Genres() {
     <Content>
       <Form>
         <Text>Which Music Do You Like?</Text>
-        <GetGenres />
+        <ChooseGenres />
         <Button size="Large">Match Me</Button>
       </Form>
     </Content>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dev:server": "npm run build && cd .. && npm start",
     "server": "nodemon index.js",
     "start": "node index.js",
-    "api": "json-server --watch db.json"
+    "api": "json-server --watch db.json --port 8080"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To generate genre buttons from the database data, I adjusted the fetch to reduce it to genres only and de-duplicated them with the concat-method. They are also sorted alphabetically. Whenever a completely new genre is added to the database, a new button will be generated.
<img width="373" alt="Screenshot 2020-04-27 at 14 43 51" src="https://user-images.githubusercontent.com/60884137/80374171-89683000-8896-11ea-9bbb-8dee4fb6fef8.png">
